### PR TITLE
fix: add OGP image metatags to static HTML output

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -3,7 +3,9 @@ import React from 'react'
 
 import { GA_TRACKING_ID } from '../lib/gtag'
 
-type Props = {}
+type Props = {
+  slug?: string | null;
+}
 // Fix: Add fallback for GA_TRACKING_ID if not in .env
 export const siteTitle = 'Coffee Break Point'
 export const siteDescription = 'コーヒー休憩にちょうどよい技術よみものを目指して'
@@ -13,20 +15,64 @@ export default class Document extends NextDocument {
     const initialProps = await NextDocument.getInitialProps(ctx);
     // サイドバーデータはgetStaticPropsから提供するため、ここでは取得しない
     
+    // 現在のパスを取得
+    const { pathname, asPath } = ctx;
+    
+    // スラッグを取得（存在する場合）
+    let slug = null;
+    
+    // パスが/posts/[slug]の形式かどうかをチェック
+    const postPathMatch = asPath.match(/\/posts\/([^\/]+)$/);
+    if (postPathMatch && postPathMatch[1]) {
+      slug = postPathMatch[1];
+    }
+    
     return { 
-      ...initialProps
+      ...initialProps,
+      slug
     };
   }
 
   render() {
+    const { slug } = this.props as Props;
+    
+    // OGP画像のURL生成（document.tsxでのみ使用）
+    const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://blog.shaba.dev';
+    const ogImageUrl = slug 
+      ? `${baseUrl}/og-images/${slug}.png` 
+      : `${baseUrl}/og-images/default.png`;
+    
+    // 現在のページのURL
+    const pageUrl = slug 
+      ? `${baseUrl}/posts/${slug}` 
+      : baseUrl;
+
+    // 画像のサイズ設定
+    const imageWidth = 1200;
+    const imageHeight = 630;
     
     return (
       <Html lang="ja">
         <Head>
+          {/* フォント関連 */}
           <link rel="preconnect" href="https://fonts.googleapis.com" />
           <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
           <link href="https://fonts.googleapis.com/css2?family=Dancing+Script:wght@400;700&display=swap" rel="stylesheet" />
           <link href="https://fonts.googleapis.com/css2?family=Caveat:wght@400;700&display=swap" rel="stylesheet" />
+          
+          {/* OGP画像設定 - 記事ページの場合のみ */}
+          {slug && (
+            <>
+              <meta property="og:image" content={ogImageUrl} />
+              <meta property="og:image:width" content={String(imageWidth)} />
+              <meta property="og:image:height" content={String(imageHeight)} />
+              <meta property="og:type" content="article" />
+              <meta property="og:url" content={pageUrl} />
+              <meta name="twitter:image" content={ogImageUrl} />
+              <meta name="twitter:card" content="summary_large_image" />
+            </>
+          )}
+          
           {/* Global Site Tag (gtag.js) - Google Analytics */}
           <script
             async
@@ -44,6 +90,7 @@ export default class Document extends NextDocument {
           `,
             }}
           />
+          
           {/*google adsense*/}
           <script 
             async 

--- a/src/themes/theme1/components/layouts/DetailLayout.tsx
+++ b/src/themes/theme1/components/layouts/DetailLayout.tsx
@@ -4,13 +4,20 @@ import styles from "./layout.module.css";
 import Link from "next/link";
 import Layout from "./layout";
 import { useRouter } from "next/router";
+import Head from "next/head";
 
 export default function ListLayout({
   children,
   leftside,
+  title,
+  description,
+  slug,
 }: {
   children: React.ReactNode;
   leftside?: React.ReactNode;
+  title?: string;
+  description?: string;
+  slug?: string;
 }) {
   const router = useRouter();
 
@@ -19,13 +26,50 @@ export default function ListLayout({
     router.back()
   }
 
+  // OGP画像のURL生成
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://blog.shaba.dev';
+  const ogImageUrl = slug 
+    ? `${baseUrl}/og-images/${slug}.png` 
+    : `${baseUrl}/og-images/default.png`;
+  
+  // 現在のページのURL
+  const pageUrl = slug 
+    ? `${baseUrl}/posts/${slug}` 
+    : baseUrl;
+  
+  // 設定されていない場合のデフォルト値
+  const pageTitle = title || 'Coffee Break Point';
+  const pageDescription = description || '日々の気付きやメモを書いていくブログです';
+  
   // background: '#e8cfc1'
   return (
-    <Layout leftside={leftside}>
-      <Container maxW="container.lg">{children}</Container>
-      <div className={styles.backToHome}>
-        <Text as="a" onClick={(e) => router.back()} _hover={{cursor: "pointer"}}> ← Back to home </Text>
-      </div>
-    </Layout>
+    <>
+      {/* OGPメタタグを追加 */}
+      {slug && (
+        <Head>
+          <meta property="og:title" content={pageTitle} />
+          <meta property="og:description" content={pageDescription} />
+          <meta property="og:url" content={pageUrl} />
+          <meta property="og:type" content="article" />
+          <meta property="og:site_name" content="Coffee Break Point" />
+          
+          <meta property="og:image" content={ogImageUrl} />
+          <meta property="og:image:width" content="1200" />
+          <meta property="og:image:height" content="630" />
+          
+          <meta name="twitter:card" content="summary_large_image" />
+          <meta name="twitter:title" content={pageTitle} />
+          <meta name="twitter:description" content={pageDescription} />
+          <meta name="twitter:image" content={ogImageUrl} />
+        </Head>
+      )}
+      
+      <Layout leftside={leftside}>
+        <Container maxW="container.lg">{children}</Container>
+        <div className={styles.backToHome}>
+          <Text as="a" onClick={(e) => router.back()} _hover={{cursor: "pointer"}}> ← Back to home </Text>
+        </div>
+      </Layout>
+    </>
   );
 }

--- a/src/themes/theme1/pages/ArticlePage.tsx
+++ b/src/themes/theme1/pages/ArticlePage.tsx
@@ -32,11 +32,17 @@ export default ({ tags, postHead, title, postDetail }: Props) => {
   const postHeadEntity:PostHeadEntity = new PostHeadEntity(postHead);
 
   return (
-    <DetailLayout leftside={
-      <Box mt="20px">
-        <SideArea tags={tags} post={postHeadEntity} title={title} />
-      </Box>
-    } >
+    <DetailLayout 
+      leftside={
+        <Box mt="20px">
+          <SideArea tags={tags} post={postHeadEntity} title={title} />
+        </Box>
+      }
+      title={postHeadEntity.title}
+      description={postHeadEntity.excerpt || ''}
+      slug={postHeadEntity.slug}
+    >
+      {/* Seoコンポーネントは互換性のために残しておきます */}
       <Seo title={postHeadEntity.title} coverImageUrl={postHeadEntity.coverImageUrl} />
       <Head> <title>{postHeadEntity.title}</title> </Head>
       <Box mt="20px">

--- a/src/themes/theme2/components/layouts/Layout.tsx
+++ b/src/themes/theme2/components/layouts/Layout.tsx
@@ -10,6 +10,7 @@ interface LayoutProps {
   description?: string;
   showSidebar?: boolean;
   sidebarContent?: ReactNode;
+  slug?: string; // 記事のスラッグ（URLパス）
 }
 
 /**
@@ -21,7 +22,19 @@ export default function Layout({
   description = "日々の気付きやメモを書いていくブログです",
   showSidebar = true,
   sidebarContent,
+  slug,
 }: LayoutProps) {
+  // OGP画像のURL生成
+  const baseUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://blog.shaba.dev';
+  const ogImageUrl = slug 
+    ? `${baseUrl}/og-images/${slug}.png` 
+    : `${baseUrl}/og-images/default.png`;
+  
+  // 現在のページのURL
+  const pageUrl = slug 
+    ? `${baseUrl}/posts/${slug}` 
+    : baseUrl;
+
   return (
     <>
       <Head>
@@ -29,6 +42,24 @@ export default function Layout({
         <meta name="description" content={description} />
         <meta name="viewport" content="width=device-width, initial-scale=1" />
         <link rel="icon" href="/favicon.ico" />
+        
+        {/* OGP基本設定 */}
+        <meta property="og:title" content={title} />
+        <meta property="og:description" content={description} />
+        <meta property="og:url" content={pageUrl} />
+        <meta property="og:type" content={slug ? "article" : "website"} />
+        <meta property="og:site_name" content="Coffee Break Point" />
+        
+        {/* OGP画像設定 */}
+        <meta property="og:image" content={ogImageUrl} />
+        <meta property="og:image:width" content="1200" />
+        <meta property="og:image:height" content="630" />
+        
+        {/* Twitter Card設定 */}
+        <meta name="twitter:card" content="summary_large_image" />
+        <meta name="twitter:title" content={title} />
+        <meta name="twitter:description" content={description} />
+        <meta name="twitter:image" content={ogImageUrl} />
       </Head>
       <div className="container">
         <Header />

--- a/src/themes/theme2/pages/ArticlePage.tsx
+++ b/src/themes/theme2/pages/ArticlePage.tsx
@@ -29,7 +29,10 @@ export default function ArticlePage({ article }: ArticlePageProps) {
     <Layout
       title={`${article.title} | Coffee Break Point`}
       description={article.excerpt || ''}
+      slug={article.slug}
     >
+      {/* Seoコンポーネントは互換性のために残しておきますが、
+          主要なOGP情報はLayoutでHTMLに直接出力されます */}
       <Seo title={article.title} slug={article.slug} />
       <ArticleDetail article={article} />
     </Layout>


### PR DESCRIPTION
## 概要
各記事ページのHTMLに、OGP画像メタタグが正しく埋め込まれていない問題を修正しました。

## 変更内容
1. `_document.tsx`を修正して、記事スラッグを取得し、OGP画像URLを生成して静的HTMLに直接埋め込むようにしました
2. Theme1とTheme2のレイアウトコンポーネントにスラッグパラメータを追加し、記事情報を正しく渡せるようにしました
3. 環境変数に`NEXT_PUBLIC_SITE_URL`を追加し、OGP画像URLの基本パスを設定しました

## 修正アプローチ
Next.jsの静的エクスポートモード（`output: 'export'`）では、クライアントサイドのコンポーネントからのメタタグが正しく反映されていませんでした。
そこで、`_document.tsx`（サーバーサイドで動作）内でパスからスラッグを抽出し、OGPメタタグを直接挿入することで解決しました。

## テスト結果
ビルド後のHTMLファイルを確認し、以下のOGP関連メタタグが正しく含まれていることを確認しました：
```
<meta property="og:image" content="https://blog.shaba.dev/og-images/update-dotfiles.png"/>
<meta property="og:image:width" content="1200"/>
<meta property="og:image:height" content="630"/>
<meta property="og:type" content="article"/>
<meta property="og:url" content="https://blog.shaba.dev/posts/update-dotfiles"/>
<meta name="twitter:image" content="https://blog.shaba.dev/og-images/update-dotfiles.png"/>
<meta name="twitter:card" content="summary_large_image"/>
```

## 影響範囲
- この修正により、SNSなどでシェアされた際に適切な画像がプレビューに表示されるようになります
- 既存の機能に影響を与えることなく、OGP情報を追加することができました

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>