### PR TITLE
fix: improve word wrapping for long text in mobile view

### DIFF
--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -27,6 +27,9 @@ body {
   font-family: "Noto Serif JP", serif;
   font-size: 16px;
   line-height: 1.8;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 a {

--- a/src/themes/theme2/components/blog/ArticleDetail.module.css
+++ b/src/themes/theme2/components/blog/ArticleDetail.module.css
@@ -14,6 +14,9 @@
   font-size: 2.2rem;
   color: var(--heading-color);
   margin-bottom: 16px;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  word-break: break-word;
 }
 
 .meta {

--- a/src/themes/theme2/components/blog/NotionBlockRenderer.module.css
+++ b/src/themes/theme2/components/blog/NotionBlockRenderer.module.css
@@ -218,9 +218,11 @@
   margin-bottom: 0.5rem;
   color: var(--link-color);
   font-size: 1.05rem;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
 }
 
 .bookmarkDescription {
@@ -249,9 +251,11 @@
 .bookmarkUrl {
   font-size: 0.8rem;
   color: #888;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  max-width: 100%;
 }
 
 .bookmarkThumbnail {

--- a/src/themes/theme2/components/mylink/MyLinkItem.module.css
+++ b/src/themes/theme2/components/mylink/MyLinkItem.module.css
@@ -100,9 +100,10 @@
   font-weight: 500;
   box-shadow: 0 1px 3px rgba(0,0,0,0.05);
   max-width: 120px;
-  white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  word-wrap: break-word;
+  overflow-wrap: break-word;
 }
 
 .tagItem:hover {


### PR DESCRIPTION
## Summary
- モバイルビューでの長い英単語が見切れる問題を修正しました
- グローバルCSSと各コンポーネントに適切なテキスト折り返し設定を追加しました
- ブックマークタイトル・URL、タグ、記事タイトルなどで特に問題があった箇所を修正しました

## Test plan
- モバイルデバイスやレスポンシブモードで表示を確認する
- 特に長い英単語を含むページでテキストが適切に折り返されることを確認する
- ブックマークやタグの表示が崩れないことを確認する

🤖 Generated with [Claude Code](https://claude.ai/code)