### PR TITLE
fix: resolve JSON serialization error in coverImage

### DIFF
--- a/src/services/CommonDataService.ts
+++ b/src/services/CommonDataService.ts
@@ -62,7 +62,7 @@ export class CommonDataService {
       // 元のポストにcoverImageプロパティを追加（タイプ互換性のため）
       return {
         ...post,
-        coverImage: coverImage || undefined
+        coverImage: coverImage || null
       };
     });
     
@@ -90,7 +90,7 @@ export class CommonDataService {
       
       return {
         ...post,
-        coverImage: coverImage || undefined
+        coverImage: coverImage || null
       };
     });
     


### PR DESCRIPTION
## Summary
- Fix build error caused by `undefined` values in `coverImage` property during static generation
- Replace `undefined` fallback with `null` to ensure proper JSON serialization compatibility

## Test plan
- [x] Run `npm run build` to verify the fix resolves the serialization error
- [x] Confirm all static pages generate successfully without errors

🤖 Generated with [Claude Code](https://claude.ai/code)