### PR TITLE
feat: integrate blog domain under shaba.dev/blog for AdSense compliance

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -4,6 +4,8 @@ const withBundleAnalyzer = require('@next/bundle-analyzer')({
 
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  basePath: '/blog',
+  assetPrefix: '/blog',
   env: {
     NEXT_PUBLIC_ACTIVE_THEME: process.env.NEXT_PUBLIC_ACTIVE_THEME || 'theme2',
     ARTICLE_SOURCE: process.env.ARTICLE_SOURCE || 'notion',

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,2 +1,6 @@
-https://blog.from-garage.com/* https://blog.shaba.dev/:splat 301!
-https://shaba.com/* https://blog.shaba.dev/:splat 302!
+# Redirect blog.shaba.dev to shaba.dev/blog for AdSense compliance
+/* https://shaba.dev/blog/:splat 301!
+
+# Legacy redirects
+https://blog.from-garage.com/* https://shaba.dev/blog/:splat 301!
+https://shaba.com/* https://shaba.dev/blog/:splat 302!


### PR DESCRIPTION
## Summary
• blog.shaba.devからshaba.dev/blogへのドメイン統合でAdSense審査対応
• Next.jsのbasePath設定でサブディレクトリ動作を実現
• プロダクト分離を維持しながらドメインを統合

## 主な変更点

### Next.js設定 (`next.config.js`)
- `basePath: '/blog'` - サブディレクトリでの動作設定
- `assetPrefix: '/blog'` - アセットファイルのパス調整

### リダイレクト設定 (`public/_redirects`)
- blog.shaba.dev → shaba.dev/blog への301リダイレクト
- レガシードメインのリダイレクト先をshaba.dev/blogに変更

## AdSense対応効果
- ✅ 全コンテンツが同一ドメイン（shaba.dev）下に統合
- ✅ blog.shaba.devのコンテンツがメインサイトの一部として認識
- ✅ プロダクト分離を維持しながらSEO効果を最大化

## 技術的詳細
この変更により、ユーザーが`shaba.dev/blog`にアクセスすると：
1. Portfolioサイトの`_redirects`でblog.shaba.devにプロキシ
2. Notiographyの`basePath`設定でサブディレクトリ動作
3. ブログコンテンツが`shaba.dev/blog`配下で正常表示

## Test plan
- [ ] shaba.dev/blogでブログが正常に表示される
- [ ] blog.shaba.devからの301リダイレクトが動作する
- [ ] アセットファイル（CSS、JS、画像）が正常に読み込まれる
- [ ] 内部リンクが正しく動作する
- [ ] レガシードメインからのリダイレクトが動作する

🤖 Generated with [Claude Code](https://claude.ai/code)