### PR TITLE
fix: correct blog pagination and article link paths

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,150 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## 開発コマンド
+
+### 基本的な開発フロー
+```bash
+# 開発サーバー起動（TOML設定の自動変換を含む）
+npm run dev
+
+# ビルド（GitHubプロフィール取得、OG画像生成、Next.js ビルドを順次実行）
+npm run build
+
+# 静的サイト配信
+npm start
+
+# テスト実行
+npm test
+npm run test:watch  # 変更監視モード
+```
+
+### 特殊なビルドコマンド
+```bash
+# OG画像生成のみ
+npm run generate-og
+
+# バンドルサイズ解析
+npm run analyze
+
+# サイトマップ生成（ビルド後に自動実行）
+npm run postbuild
+```
+
+### 重要な前処理
+- `npm run dev`と`npm run build`の前に`convert-toml-to-json.js`が自動実行される
+- TOML設定ファイル（`src/config/site.toml`）がJSONに変換され`public/config/site-config.json`に出力される
+
+## プロジェクト構成
+
+### アーキテクチャ概要
+このプロジェクトは**Next.js静的サイト生成**を基盤とした技術ブログで、以下の特徴を持つ：
+
+- **Notion API連携**: 記事コンテンツをNotionから取得
+- **多段階ビルドプロセス**: GitHubプロフィール取得 → OG画像生成 → Next.jsビルド
+- **レイヤー分離アーキテクチャ**: Clean Architectureパターンを採用
+
+### ディレクトリ構造
+```
+src/
+├── application/           # アプリケーション層
+│   ├── modules/          # ドメイン別モジュール
+│   │   └── mylink/       # MyLinkドメイン（外部リンク管理）
+│   │       ├── logic/    # ビジネスロジック
+│   │       ├── objects/  # データオブジェクト（Entity, DTO, DXO）
+│   │       └── repositories/ # データアクセス層
+│   └── usecases/         # ユースケース実装
+├── components/           # Reactコンポーネント
+├── config/              # 設定ファイル
+│   └── site.toml        # サイト設定（TOML形式）
+├── core/                # 型定義
+│   └── types/           # 共通型定義
+├── lib/                 # ユーティリティ・共通機能
+├── pages/               # Next.jsページ
+├── services/            # 外部サービス連携
+├── styles/              # スタイル定義
+├── tests/               # テストファイル
+└── themes/              # テーマ設定
+```
+
+### 重要な設計パターン
+
+#### 1. レイヤー分離
+- **Application Layer**: ビジネスロジックとユースケース
+- **Core Layer**: 型定義とドメインオブジェクト
+- **Infrastructure**: 外部API連携（Notion、GitHub等）
+
+#### 2. モジュール構成（application/modules/）
+各ドメインは以下の構造を持つ：
+- `logic/`: ビジネスロジック実装
+- `objects/entities/`: ドメインエンティティ
+- `objects/dtos/`: データ転送オブジェクト
+- `objects/dxos/`: データ交換オブジェクト
+- `repositories/`: データアクセス抽象化
+
+#### 3. 設定管理
+- TOMLファイル（`src/config/site.toml`）で設定を管理
+- ビルド時にJSONに変換されクライアントサイドからアクセス可能
+
+## 技術スタック
+
+### フレームワーク・ライブラリ
+- **Next.js 15**: 静的サイト生成（SSG）
+- **React 18**: UIライブラリ
+- **Chakra UI**: UIコンポーネントライブラリ
+- **TypeScript**: 型安全性確保
+
+### 外部サービス連携
+- **Notion API**: 記事コンテンツ管理
+- **GitHub API**: プロフィール情報取得
+- **Netlify**: ホスティング・デプロイ
+
+### テスト環境
+- **Jest**: テストフレームワーク
+- **@testing-library/react**: React コンポーネントテスト
+- **@testing-library/jest-dom**: DOM テスト拡張
+
+## 開発時の注意事項
+
+### ビルド設定
+- TypeScript型チェックとESLintは一時的に無効化されている（`next.config.js`）
+- 画像最適化は無効化（静的出力のため）
+- `/posts/*` から `/blog/posts/*` へのリダイレクト設定あり
+
+### 環境変数
+- `NEXT_PUBLIC_ACTIVE_THEME`: アクティブテーマ設定（デフォルト: theme2）
+- `ARTICLE_SOURCE`: 記事ソース設定（デフォルト: notion）
+- `BUILD_TIME`: OG画像のキャッシュバスティング用
+
+### テスト実行
+```bash
+# 全テスト実行
+npm test
+
+# 単一テスト実行例
+npm test src/tests/unit/lib/config.test.ts
+
+# 監視モード
+npm run test:watch
+```
+
+### 設定変更時の注意
+- `src/config/site.toml`を編集した場合、開発サーバー再起動で自動的にJSONに変換される
+- OG画像生成は重い処理のため、必要時のみ`npm run generate-og`を実行
+
+## 特殊な機能
+
+### OG画像自動生成
+- 記事ごとのOG画像を動的生成
+- Canvas APIとSkia-canvasを使用
+- ビルド時に自動実行、または手動で`npm run generate-og`
+
+### GitHub プロフィール連携
+- ビルド時にGitHubプロフィール情報を取得
+- 著者情報の動的更新
+
+### Notion連携アーキテクチャ
+- `BaseNotionRepository`を基盤としたリポジトリパターン
+- Notion APIレスポンスの型安全な変換処理
+- 記事とMyLink（外部リンク）の統一管理

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Notiography",
+  "name": "shabaraba",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
@@ -14362,16 +14362,6 @@
       "version": "1.0.2",
       "license": "MIT"
     },
-    "node_modules/netlify-cli/node_modules/@types/body-parser": {
-      "version": "1.19.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/connect": "*",
-        "@types/node": "*"
-      }
-    },
     "node_modules/netlify-cli/node_modules/@types/cacheable-request": {
       "version": "6.0.2",
       "license": "MIT",
@@ -14380,15 +14370,6 @@
         "@types/keyv": "*",
         "@types/node": "*",
         "@types/responselike": "*"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@types/connect": {
-      "version": "3.4.35",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/netlify-cli/node_modules/@types/decompress": {
@@ -14405,29 +14386,6 @@
         "@types/decompress": "*",
         "@types/got": "^8",
         "@types/node": "*"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@types/express": {
-      "version": "4.17.13",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/body-parser": "*",
-        "@types/express-serve-static-core": "^4.17.18",
-        "@types/qs": "*",
-        "@types/serve-static": "*"
-      }
-    },
-    "node_modules/netlify-cli/node_modules/@types/express-serve-static-core": {
-      "version": "4.17.28",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/qs": "*",
-        "@types/range-parser": "*"
       }
     },
     "node_modules/netlify-cli/node_modules/@types/glob": {
@@ -14463,12 +14421,6 @@
         "@types/node": "*"
       }
     },
-    "node_modules/netlify-cli/node_modules/@types/mime": {
-      "version": "1.3.2",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
     "node_modules/netlify-cli/node_modules/@types/minimatch": {
       "version": "5.1.2",
       "license": "MIT"
@@ -14476,18 +14428,6 @@
     "node_modules/netlify-cli/node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
       "license": "MIT"
-    },
-    "node_modules/netlify-cli/node_modules/@types/qs": {
-      "version": "6.9.7",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
-    },
-    "node_modules/netlify-cli/node_modules/@types/range-parser": {
-      "version": "1.2.4",
-      "license": "MIT",
-      "optional": true,
-      "peer": true
     },
     "node_modules/netlify-cli/node_modules/@types/responselike": {
       "version": "1.0.0",
@@ -14503,16 +14443,6 @@
     "node_modules/netlify-cli/node_modules/@types/semver": {
       "version": "7.3.9",
       "license": "MIT"
-    },
-    "node_modules/netlify-cli/node_modules/@types/serve-static": {
-      "version": "1.13.10",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "@types/mime": "^1",
-        "@types/node": "*"
-      }
     },
     "node_modules/netlify-cli/node_modules/@types/yauzl": {
       "version": "2.10.0",

--- a/src/components/ArticleCard.tsx
+++ b/src/components/ArticleCard.tsx
@@ -28,7 +28,7 @@ const ArticleCard: React.FC<ArticleCardProps> = ({ article }) => {
   return (
     <article className={styles.card}>
       <a 
-        href={`/posts/${article.slug}`}
+        href={`/blog/posts/${article.slug}`}
         className={styles.cardLink}
       >
         {article.coverImage && (

--- a/src/components/ArticlesSection.tsx
+++ b/src/components/ArticlesSection.tsx
@@ -35,7 +35,7 @@ const ArticlesSection: React.FC<ArticlesSectionProps> = ({ articles }) => {
           <div key={article.id} className={styles.articleCard}>
             <div className={styles.articleContent}>
               <a 
-                href={`/posts/${article.slug}`}
+                href={`/blog/posts/${article.slug}`}
                 className={styles.articleLink}
               >
                 <div className={styles.articleInfo}>

--- a/src/themes/theme2/components/blog/ArticleDetail.tsx
+++ b/src/themes/theme2/components/blog/ArticleDetail.tsx
@@ -95,7 +95,7 @@ export default function ArticleDetail({ article }: ArticleDetailProps) {
             </a>
           </div>
         </div>
-        <Link href="/" className={styles.backLink}>
+        <Link href="/blog" className={styles.backLink}>
           ← ホームへ戻る
         </Link>
       </footer>

--- a/src/themes/theme2/components/blog/ArticleDetail.tsx
+++ b/src/themes/theme2/components/blog/ArticleDetail.tsx
@@ -67,7 +67,7 @@ export default function ArticleDetail({ article }: ArticleDetailProps) {
           <span className={styles.shareLabel}>この記事をシェアする:</span>
           <div className={styles.shareButtons}>
             <a 
-              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(article.title)}&url=${encodeURIComponent(`https://blog.shaba.dev/posts/${article.slug}`)}`} 
+              href={`https://twitter.com/intent/tweet?text=${encodeURIComponent(article.title)}&url=${encodeURIComponent(`https://blog.shaba.dev/blog/posts/${article.slug}`)}`} 
               target="_blank" 
               rel="noopener noreferrer" 
               className={styles.shareButton}
@@ -76,7 +76,7 @@ export default function ArticleDetail({ article }: ArticleDetailProps) {
               <FaXTwitter size={20} />
             </a>
             <a 
-              href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(`https://blog.shaba.dev/posts/${article.slug}`)}`} 
+              href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(`https://blog.shaba.dev/blog/posts/${article.slug}`)}`} 
               target="_blank" 
               rel="noopener noreferrer" 
               className={styles.shareButton}
@@ -85,7 +85,7 @@ export default function ArticleDetail({ article }: ArticleDetailProps) {
               <FaFacebook size={20} />
             </a>
             <a 
-              href={`https://b.hatena.ne.jp/entry/s/${encodeURIComponent(`blog.shaba.dev/posts/${article.slug}`).replace(/^https?:\/\//, '')}`}
+              href={`https://b.hatena.ne.jp/entry/s/${encodeURIComponent(`blog.shaba.dev/blog/posts/${article.slug}`).replace(/^https?:\/\//, '')}`}
               target="_blank" 
               rel="noopener noreferrer" 
               className={styles.shareButton}

--- a/src/themes/theme2/components/blog/ArticleList.tsx
+++ b/src/themes/theme2/components/blog/ArticleList.tsx
@@ -18,7 +18,7 @@ export default function ArticleList({ articles }: ArticleListProps) {
         <article key={article.id} className={styles.articleCard}>
           {article.coverImage && (
             <div className={styles.articleImage}>
-              <Link href={`/posts/${article.slug}`}>
+              <Link href={`/blog/posts/${article.slug}`}>
                 <Image 
                   src={article.coverImage} 
                   alt={article.title} 
@@ -31,7 +31,7 @@ export default function ArticleList({ articles }: ArticleListProps) {
           )}
           <div className={styles.articleContent}>
             <h2 className={styles.articleTitle}>
-              <Link href={`/posts/${article.slug}`} className={styles.titleLink}>
+              <Link href={`/blog/posts/${article.slug}`} className={styles.titleLink}>
                 {article.title}
               </Link>
             </h2>
@@ -60,7 +60,7 @@ export default function ArticleList({ articles }: ArticleListProps) {
             {article.excerpt && (
               <p className={styles.articleExcerpt}>{article.excerpt}</p>
             )}
-            <Link href={`/posts/${article.slug}`} className={styles.readMore}>
+            <Link href={`/blog/posts/${article.slug}`} className={styles.readMore}>
               続きを読む →
             </Link>
           </div>

--- a/src/themes/theme2/components/blog/RelatedArticles.tsx
+++ b/src/themes/theme2/components/blog/RelatedArticles.tsx
@@ -24,7 +24,7 @@ export default function RelatedArticles({ articles }: RelatedArticlesProps) {
         {articles.map((article) => (
           <Link 
             key={article.id} 
-            href={`/posts/${article.slug}`} 
+            href={`/blog/posts/${article.slug}`} 
             className={styles.relatedItem}
           >
             <div className={styles.relatedThumbnail}>

--- a/src/themes/theme2/components/layouts/Header.tsx
+++ b/src/themes/theme2/components/layouts/Header.tsx
@@ -15,7 +15,7 @@ export default function Header() {
   return (
     <header className={styles.header}>
       <div className={styles.logoContainer}>
-        <Link href="/" className={styles.logo}>
+        <Link href="/blog" className={styles.logo}>
           <span className={styles.logoText}>
             Coffee Break Point
           </span>
@@ -24,7 +24,7 @@ export default function Header() {
       <nav className={styles.nav}>
         <ul className={styles.navList}>
           <li className={styles.navItem}>
-            <Link href="/" className={styles.navLink}>
+            <Link href="/blog" className={styles.navLink}>
               { homeText }
             </Link>
           </li>

--- a/src/themes/theme2/components/sidebar/PopularArticles.tsx
+++ b/src/themes/theme2/components/sidebar/PopularArticles.tsx
@@ -23,7 +23,7 @@ export default function PopularArticles() {
       <ul className={styles.articleList}>
         {trendingPosts.map((article) => (
           <li key={article.id} className={styles.articleItem}>
-            <Link href={`/posts/${article.slug}`} className={styles.articleLink}>
+            <Link href={`/blog/posts/${article.slug}`} className={styles.articleLink}>
               {article.title}
             </Link>
           </li>

--- a/src/themes/theme2/pages/HomePage.tsx
+++ b/src/themes/theme2/pages/HomePage.tsx
@@ -91,7 +91,7 @@ const HomePage = React.memo(function HomePage({
         totalItems={paginationSettings.totalItems}
         itemsPerPage={paginationSettings.itemsPerPage}
         currentPage={paginationSettings.currentPage}
-        baseUrl={tagName ? `/tags/${tagName.toLowerCase()}` : '/'}
+        baseUrl={tagName ? `/tags/${tagName.toLowerCase()}` : '/blog'}
         queryParams={queryParams}
       />
     </Layout>


### PR DESCRIPTION
## Summary
- ブログページのページネーションリンクが`shaba.dev?page=2`になっていた問題を修正
- 記事リンクが`/posts/`パスを使用していた問題を`/blog/posts/`に修正
- ソーシャルシェアリンクも正しいパスに更新

## 修正内容
- **ページネーション修正**: HomePage.tsx のbaseUrlを`/`から`/blog`に変更
- **記事リンク修正**: 以下のコンポーネントで記事リンクを`/posts/`から`/blog/posts/`に変更:
  - ArticleCard, ArticlesSection, PopularArticles
  - ArticleList, RelatedArticles, ArticleDetail
- **ソーシャルシェアリンク**: Twitter、Facebook、はてなブックマークのリンクパスも修正
- **ドキュメント追加**: 開発用のCLAUDE.mdファイルを追加

## Test plan
- [x] 開発サーバー起動確認済み
- [x] ページネーションリンクが`/blog?page=2`形式で生成されることを確認
- [x] 記事リンクが`/blog/posts/[slug]`形式で生成されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)