### PR TITLE
chore: remove unnecessary Netlify plugins for static site

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -3,11 +3,10 @@
     command = "pnpm run build"
 
 [build.environment]
-    NETLIFY_NEXT_PLUGIN_SKIP = "true"
     NODE_VERSION = "22"
     NODE_OPTIONS = "--max-old-space-size=4096"
     PYTHON_VERSION = "3.9"
-    
+
 [build.processing]
     skip_processing = false
 
@@ -15,7 +14,3 @@
     compress = true
 [functions]
   directory = "src/netlify/functions"
-[[plugins]]
-  package = "@netlify/plugin-nextjs"
-[[plugins]]
-  package = "netlify-plugin-cache-nextjs"


### PR DESCRIPTION
## Summary
- Netlifyの不要なプラグインを削除
- 静的サイト生成（SSG）のみを使用しているため、Next.js関連のプラグインは不要

## 変更内容
### 削除したプラグイン
- `@netlify/plugin-nextjs`: SSR/ISR機能を提供するが、このプロジェクトは完全な静的出力（`output: 'export'`）のため不要
- `netlify-plugin-cache-nextjs`: Next.jsのサーバー機能向けキャッシュプラグインで、静的サイトには不要

### 削除した環境変数
- `NETLIFY_NEXT_PLUGIN_SKIP`: プラグイン自体を削除したため不要

## 背景
Netlifyが[レガシープリレンダリング機能の廃止](https://www.netlify.com/changelog/2025-12-16-prerender-extension-ga/)を発表したため、設定を見直し。

このプロジェクトは：
- ✅ 完全な静的HTML生成（SSG）
- ✅ ビルド時に全ページを事前生成
- ❌ プリレンダリング機能は未使用
- ❌ Prerender拡張機能も不要

結論として、プラグインを削除してシンプルな静的サイト配信に最適化。

## Test plan
- [x] ローカルビルドが正常に動作すること
- [ ] Netlifyでのデプロイが正常に完了すること
- [ ] サイトが正常に表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified build configuration by removing legacy environment variables and plugin dependencies.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->