### PR TITLE
fix: respect ARTICLE_SOURCE in OG image generation

### DIFF
--- a/scripts/fetch-article-og-images.js
+++ b/scripts/fetch-article-og-images.js
@@ -33,7 +33,7 @@ const OG_IMAGES_DIR = path.join(process.cwd(), 'public', 'og-images');
  * Note: raw.githubusercontent.comはレート制限なし
  */
 async function fetchOGImagesList() {
-  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/og-images?ref=${GITHUB_BRANCH}`;
+  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/images/og-images?ref=${GITHUB_BRANCH}`;
 
   const response = await fetch(url, {
     headers: {
@@ -44,7 +44,7 @@ async function fetchOGImagesList() {
 
   if (!response.ok) {
     if (response.status === 404) {
-      console.log('⚠️  og-images ディレクトリが見つかりません');
+      console.log('⚠️  images/og-images ディレクトリが見つかりません');
       return [];
     }
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);

--- a/scripts/fetch-article-og-images.js
+++ b/scripts/fetch-article-og-images.js
@@ -10,9 +10,21 @@
 const fs = require('fs');
 const path = require('path');
 
+// INCOMING_HOOK_BODYからarticlesブランチを取得
+let articlesBranch = 'main';
+if (process.env.INCOMING_HOOK_BODY) {
+  try {
+    const hookBody = JSON.parse(process.env.INCOMING_HOOK_BODY);
+    articlesBranch = hookBody.articles_branch || 'main';
+    console.log(`📌 Using articles branch: ${articlesBranch}`);
+  } catch (e) {
+    console.log('⚠️  Failed to parse INCOMING_HOOK_BODY, using main branch');
+  }
+}
+
 const GITHUB_OWNER = process.env.GITHUB_OWNER || 'shabaraba';
 const GITHUB_REPO = process.env.GITHUB_REPO || 'Articles';
-const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'main';
+const GITHUB_BRANCH = process.env.GITHUB_BRANCH || articlesBranch;
 
 const OG_IMAGES_DIR = path.join(process.cwd(), 'public', 'og-images');
 

--- a/scripts/fetch-cover-images.js
+++ b/scripts/fetch-cover-images.js
@@ -34,7 +34,7 @@ const COVERS_DIR = path.join(process.cwd(), 'public', 'images', 'covers');
  * Note: raw.githubusercontent.comはレート制限なし
  */
 async function fetchCoverImagesList() {
-  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/covers?ref=${GITHUB_BRANCH}`;
+  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/images/covers?ref=${GITHUB_BRANCH}`;
 
   const response = await fetch(url, {
     headers: {
@@ -45,7 +45,7 @@ async function fetchCoverImagesList() {
 
   if (!response.ok) {
     if (response.status === 404) {
-      console.log('⚠️  covers ディレクトリが見つかりません');
+      console.log('⚠️  images/covers ディレクトリが見つかりません');
       return [];
     }
     throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);

--- a/scripts/fetch-cover-images.js
+++ b/scripts/fetch-cover-images.js
@@ -11,9 +11,21 @@ const fs = require('fs');
 const path = require('path');
 const https = require('https');
 
+// INCOMING_HOOK_BODYからarticlesブランチを取得
+let articlesBranch = 'main';
+if (process.env.INCOMING_HOOK_BODY) {
+  try {
+    const hookBody = JSON.parse(process.env.INCOMING_HOOK_BODY);
+    articlesBranch = hookBody.articles_branch || 'main';
+    console.log(`📌 Using articles branch: ${articlesBranch}`);
+  } catch (e) {
+    console.log('⚠️  Failed to parse INCOMING_HOOK_BODY, using main branch');
+  }
+}
+
 const GITHUB_OWNER = process.env.GITHUB_OWNER || 'shabaraba';
-const GITHUB_REPO = process.env.GITHUB_REPO || 'Articles'; // 正しいリポジトリ名
-const GITHUB_BRANCH = process.env.GITHUB_BRANCH || 'main';
+const GITHUB_REPO = process.env.GITHUB_REPO || 'Articles';
+const GITHUB_BRANCH = process.env.GITHUB_BRANCH || articlesBranch;
 
 const COVERS_DIR = path.join(process.cwd(), 'public', 'images', 'covers');
 

--- a/src/core/implementations/github/GitHubArticleRepository.ts
+++ b/src/core/implementations/github/GitHubArticleRepository.ts
@@ -18,10 +18,22 @@ export class GitHubArticleRepository implements ArticleRepository {
   private articlesCache: Map<string, any> = new Map();
 
   constructor() {
+    // INCOMING_HOOK_BODYからarticlesブランチを取得
+    let articlesBranch = 'main';
+    if (process.env.INCOMING_HOOK_BODY) {
+      try {
+        const hookBody = JSON.parse(process.env.INCOMING_HOOK_BODY);
+        articlesBranch = hookBody.articles_branch || 'main';
+        console.log(`[GitHubArticleRepository] Using articles branch: ${articlesBranch}`);
+      } catch (e) {
+        console.log('[GitHubArticleRepository] Failed to parse INCOMING_HOOK_BODY, using main branch');
+      }
+    }
+
     this.client = new GitHubClient({
       owner: process.env.GITHUB_OWNER || 'shabaraba',
       repo: process.env.GITHUB_REPO || 'articles',
-      branch: process.env.GITHUB_BRANCH || 'main',
+      branch: process.env.GITHUB_BRANCH || articlesBranch,
       token: process.env.GITHUB_TOKEN,
     });
   }


### PR DESCRIPTION
## 概要
OG画像生成スクリプトが`ARTICLE_SOURCE`環境変数を正しく尊重するように修正しました。

## 問題
従来、`generate-og-images.js`は`ARTICLE_SOURCE=github`の場合でも、常にNotionへアクセスを試みていました。これにより：
- 不要なNotion API呼び出しが発生
- ログに混乱を招くメッセージが表示される

## 修正内容
`ARTICLE_SOURCE`の値に応じて処理を分岐：
- `ARTICLE_SOURCE=github` または `markdown`：Markdownファイルのみを処理
- `ARTICLE_SOURCE=notion`：Notionのみをクエリ

## テスト計画
- [ ] `ARTICLE_SOURCE=github`でビルドし、Notionへのアクセスが発生しないことを確認
- [ ] `ARTICLE_SOURCE=notion`でビルドし、正常にNotion記事のOG画像が生成されることを確認
- [ ] 生成されたOG画像が正しく表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dynamic branch selection for article sources via incoming webhook settings.
  * Conditional OG image generation: Notion sources trigger OG generation; GitHub/Markdown use pre-generated images; thumbnail fallback if no Notion posts.
  * Updated image directory targets so cover and OG image lookups use the new images/… locations.

* **Refactor**
  * Streamlined article-source branching and related processing flows.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->